### PR TITLE
Route priority bugfix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ libraryDependencies ++= Seq(
   "com.amazonaws"       % "aws-java-sdk"  % "1.6.2",
   "net.java.dev.jets3t" % "jets3t"        % "0.9.0",
   "org.apache.mesos"    % "mesos"         % "0.14.2",
-  "mesosphere"          % "mesos-utils"   % "0.0.6"
+  "mesosphere"          % "mesos-utils"   % "0.0.6",
+  "org.scalatest" 		%% "scalatest" 	  % "2.0.M5b" % "test"
 )
 
 unmanagedSourceDirectories in Compile <+= baseDirectory / "src/main/scala"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
   "net.java.dev.jets3t" % "jets3t"        % "0.9.0",
   "org.apache.mesos"    % "mesos"         % "0.14.2",
   "mesosphere"          % "mesos-utils"   % "0.0.6",
-  "org.scalatest"       %% "scalatest"    % "2.0.M5b" % "test"
+  "org.scalatest"      %% "scalatest"     % "2.0.M5b" % "test"
 )
 
 unmanagedSourceDirectories in Compile <+= baseDirectory / "src/main/scala"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
   "net.java.dev.jets3t" % "jets3t"        % "0.9.0",
   "org.apache.mesos"    % "mesos"         % "0.14.2",
   "mesosphere"          % "mesos-utils"   % "0.0.6",
-  "org.scalatest" 		%% "scalatest" 	  % "2.0.M5b" % "test"
+  "org.scalatest"       %% "scalatest"    % "2.0.M5b" % "test"
 )
 
 unmanagedSourceDirectories in Compile <+= baseDirectory / "src/main/scala"

--- a/src/main/scala/mesosphere/sssp/Routes.scala
+++ b/src/main/scala/mesosphere/sssp/Routes.scala
@@ -8,9 +8,7 @@ class Routes extends mutable.Map[Seq[String], S3Notary] {
   val routes: TMap[Seq[String], S3Notary] = TMap()
 
   def deepestHandler(path: Seq[String]): Option[(Seq[String], S3Notary)] =
-    path.inits.flatMap { prefix =>
-      get(prefix).map { notary => (prefix, notary) }
-    }.take(1).toSeq.headOption
+    path.inits.flatMap(pre => get(pre).map((pre, _))).take(1).toSeq.headOption
 
   def -=(k: Seq[String]): Routes.this.type = {
     routes.single -= k

--- a/src/main/scala/mesosphere/sssp/Routes.scala
+++ b/src/main/scala/mesosphere/sssp/Routes.scala
@@ -8,7 +8,9 @@ class Routes extends mutable.Map[Seq[String], S3Notary] {
   val routes: TMap[Seq[String], S3Notary] = TMap()
 
   def deepestHandler(path: Seq[String]): Option[(Seq[String], S3Notary)] =
-    path.inits.map(pre => get(pre).map((pre, _))).toSeq.flatten.lastOption
+    path.inits.flatMap { prefix =>
+      get(prefix).map { notary => (prefix, notary) }
+    }.take(1).toSeq.headOption
 
   def -=(k: Seq[String]): Routes.this.type = {
     routes.single -= k

--- a/test/scala/mesosphere/sssp/test/RoutesSpec.scala
+++ b/test/scala/mesosphere/sssp/test/RoutesSpec.scala
@@ -1,6 +1,7 @@
 package mesosphere.sssp.test
 
-import mesosphere.sssp.{ Routes, S3Notary }
+import mesosphere.sssp.{Routes, S3Notary}
+
 
 class RoutesSpec extends Spec {
 

--- a/test/scala/mesosphere/sssp/test/RoutesSpec.scala
+++ b/test/scala/mesosphere/sssp/test/RoutesSpec.scala
@@ -1,0 +1,33 @@
+package mesosphere.sssp.test
+
+import mesosphere.sssp.{ Routes, S3Notary }
+
+class RoutesSpec extends Spec {
+
+  case class Fixture() { val routes = new Routes() }
+
+  "RoutesSpec" should "select the deepest (most specific) route for a path" in {
+    val f = Fixture()
+    val notaryA = new S3Notary("bucketA")
+    val notaryB = new S3Notary("bucketB")
+    val notaryC = new S3Notary("bucketC")
+
+    val pathA = Seq("a", "b")
+    val pathB = Seq("a", "b", "c")
+    val pathC = Seq("a", "a", "c")
+
+    f.routes += pathA -> notaryA
+    f.routes += pathB -> notaryB
+    f.routes += pathC -> notaryC
+
+    val query1 = Seq("a", "b", "x")
+    f.routes.deepestHandler(query1) should equal (pathA -> notaryA)
+
+    val query2 = Seq("a", "b", "c", "x")
+    f.routes.deepestHandler(query2) should equal (pathB -> notaryB)
+
+    val query3 = Seq("a", "a", "c")
+    f.routes.deepestHandler(query3) should equal (pathC -> notaryC)
+  }
+	
+}

--- a/test/scala/mesosphere/sssp/test/RoutesSpec.scala
+++ b/test/scala/mesosphere/sssp/test/RoutesSpec.scala
@@ -21,13 +21,13 @@ class RoutesSpec extends Spec {
     f.routes += pathC -> notaryC
 
     val query1 = Seq("a", "b", "x")
-    f.routes.deepestHandler(query1) should equal (pathA -> notaryA)
+    f.routes.deepestHandler(query1) should equal (Some(pathA -> notaryA))
 
     val query2 = Seq("a", "b", "c", "x")
-    f.routes.deepestHandler(query2) should equal (pathB -> notaryB)
+    f.routes.deepestHandler(query2) should equal (Some(pathB -> notaryB))
 
     val query3 = Seq("a", "a", "c")
-    f.routes.deepestHandler(query3) should equal (pathC -> notaryC)
+    f.routes.deepestHandler(query3) should equal (Some(pathC -> notaryC))
   }
 	
 }

--- a/test/scala/mesosphere/sssp/test/Spec.scala
+++ b/test/scala/mesosphere/sssp/test/Spec.scala
@@ -3,4 +3,5 @@ package mesosphere.sssp.test
 import org.scalatest.FlatSpec
 import org.scalatest.matchers.ShouldMatchers
 
+
 trait Spec extends FlatSpec with ShouldMatchers

--- a/test/scala/mesosphere/sssp/test/Spec.scala
+++ b/test/scala/mesosphere/sssp/test/Spec.scala
@@ -1,0 +1,6 @@
+package mesosphere.sssp.test
+
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+
+trait Spec extends FlatSpec with ShouldMatchers


### PR DESCRIPTION
Added [scalatest](http://www.scalatest.org) as a dependency in the `test` scope, used same to test route priority logic.  Here we see the failed test output pre-bugfix:

```
[sssp] $ test-only mesosphere.sssp.test.RoutesSpec
[info] Compiling 1 Scala source to /Users/connor/projects/mesosphere/sssp/target/scala-2.10/test-classes...
[info] RoutesSpec:
[info] RoutesSpec
[info] - should select the deepest (most specific) route for a path *** FAILED ***
[info]   Some((List(a, b),mesosphere.sssp.S3Notary@64fba3f6)) did not equal Some((List(a, b, c),mesosphere.sssp.S3Notary@4180874)) (RoutesSpec.scala:27)
[error] Failed: Total 1, Failed 1, Errors 0, Passed 0
[error] Failed tests:
[error]     mesosphere.sssp.test.RoutesSpec
```

And post-bugfix:

```
[sssp] $ test-only mesosphere.sssp.test.RoutesSpec
[info] Compiling 1 Scala source to /Users/connor/projects/mesosphere/sssp/target/scala-2.10/classes...
[info] Compiling 1 Scala source to /Users/connor/projects/mesosphere/sssp/target/scala-2.10/test-classes...
[info] RoutesSpec:
[info] RoutesSpec
[info] - should select the deepest (most specific) route for a path
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
```
